### PR TITLE
遷移やレイアウト調整

### DIFF
--- a/resources/views/layouts/navigation.blade.php
+++ b/resources/views/layouts/navigation.blade.php
@@ -13,12 +13,13 @@
                 </div>
 
                 <div class="hidden sm:flex">
-                    <!--  -->
-                    <div class="shrink-0 mx-4 flex items-center">
-                        <a href="{{ route('post.myPosts') }}">
-                            <p>myPosts</p>
-                        </a>
-                    </div>
+                    @auth
+                        <div class="shrink-0 mx-4 flex items-center">
+                            <a href="{{ route('post.myPosts') }}">
+                                <p>自分の投稿</p>
+                            </a>
+                        </div>
+                    @endauth
                 </div>
 
             </div>
@@ -93,7 +94,7 @@
                     </x-responsive-nav-link>
 
                     <x-responsive-nav-link :href="route('post.myPosts')">
-                        <p>myPosts</p>
+                        <p>自分の投稿</p>
                     </x-responsive-nav-link>
 
                     <!-- Authentication -->

--- a/resources/views/myPosts.blade.php
+++ b/resources/views/myPosts.blade.php
@@ -14,7 +14,8 @@
             <!-- 投稿グリッド -->
             <div class="grid grid-cols-1 md:grid-cols-2 xl:grid-cols-3 gap-6 mb-10">
                 @foreach($myPosts as $myPost)
-                    <article class="bg-white border border-gray-200 rounded-lg overflow-hidden hover:transform hover:-translate-y-1 hover:shadow-lg transition-all duration-300 cursor-pointer">
+                <article class="bg-white border border-gray-200 rounded-lg overflow-hidden hover:transform hover:-translate-y-1 hover:shadow-lg transition-all duration-300 cursor-pointer">
+                    <a href="{{ route('post.show', $myPost->id) }}" class="block">
                         <!-- 画像 -->
                         <div class="aspect-w-16 aspect-h-9">
                             @if($myPost->image_path)
@@ -27,7 +28,7 @@
                                 </div>
                             @endif
                         </div>
-                        
+                
                         <!-- コンテンツ -->
                         <div class="p-5">
                             <h3 class="text-xl font-semibold text-gray-800 mb-3">{{ $myPost->title }}</h3>
@@ -41,14 +42,18 @@
                                     {{ $myPost->category_id->label() }}
                                 </span>
                             </div>
-                            <div class="mt-4">
-                                <a href="{{ route('edit.article', $myPost->id) }}" 
-                                   class="bg-orange-500 hover:bg-orange-600 text-white font-bold py-2 px-4 rounded-lg transition duration-300 ease-in-out">
-                                    編集
-                                </a>
-                            </div>
                         </div>
-                    </article>
+                    </a>
+                
+                    <!-- 編集ボタンだけ別 -->
+                    <div class="p-5">
+                        <a href="{{ route('edit.article', $myPost->id) }}" 
+                           class="bg-orange-500 hover:bg-orange-600 text-white font-bold py-2 px-4 rounded-lg transition duration-300 ease-in-out">
+                            編集
+                        </a>
+                    </div>
+                </article>
+                
                 @endforeach
             </div>
 

--- a/resources/views/myPosts.blade.php
+++ b/resources/views/myPosts.blade.php
@@ -4,8 +4,9 @@
         <main class="bg-white rounded-lg shadow-md p-6 sm:p-8">
             <!-- ヘッダーセクション -->
             <div class="flex flex-col sm:flex-row justify-between items-start sm:items-center mb-8 pb-6 border-b-2 border-gray-200">
-                <h1 class="text-3xl font-bold text-gray-800 mb-4 sm:mb-0">Your Posts</h1>
-                <a href="{{ route('create.article') }}" class="bg-blue-500 hover:bg-blue-600 text-white font-bold py-2 px-4 rounded-lg transition duration-300 ease-in-out">
+                <h1 class="text-3xl font-bold text-gray-800 mb-4 sm:mb-0">自分の投稿</h1>
+                <a href="{{ route('create.article') }}" 
+                   class="bg-blue-500 hover:bg-blue-600 text-white font-bold py-2 px-4 rounded-lg transition duration-300 ease-in-out">
                     新規作成
                 </a>
             </div>
@@ -14,12 +15,10 @@
             <div class="grid grid-cols-1 md:grid-cols-2 xl:grid-cols-3 gap-6 mb-10">
                 @foreach($myPosts as $myPost)
                     <article class="bg-white border border-gray-200 rounded-lg overflow-hidden hover:transform hover:-translate-y-1 hover:shadow-lg transition-all duration-300 cursor-pointer">
-                        <!-- 画像プレースホルダー -->
+                        <!-- 画像 -->
                         <div class="aspect-w-16 aspect-h-9">
                             @if($myPost->image_path)
-                                <div class="mb-4">
-                                    <img src="{{ $myPost->image_path }}" alt="サンプル画像" class="w-full rounded-lg">
-                                </div>
+                                <img src="{{ $myPost->image_path }}" alt="サンプル画像" class="w-full h-48 object-cover">
                             @else
                                 <div class="w-full h-48 bg-gradient-to-br from-gray-200 to-gray-300 flex items-center justify-center">
                                     <svg class="w-12 h-12 text-gray-400" fill="none" viewBox="0 0 24 24" stroke="currentColor">
@@ -32,19 +31,21 @@
                         <!-- コンテンツ -->
                         <div class="p-5">
                             <h3 class="text-xl font-semibold text-gray-800 mb-3">{{ $myPost->title }}</h3>
-                            
-                            <!-- メタ情報 -->
                             <div class="flex flex-wrap items-center gap-2 mb-4 text-sm text-gray-600">
                                 <span class="font-medium">{{ $myPost->user->name }}</span>
                                 <span class="text-gray-400">•</span>
                                 <span>{{ $myPost->created_at->format('Y-m-d H:i') }}</span>
                             </div>
-                            
-                            <!-- カテゴリ -->
                             <div class="mt-3">
                                 <span class="inline-block bg-gray-200 text-gray-700 px-3 py-1 rounded-full text-sm font-medium">
                                     {{ $myPost->category_id->label() }}
                                 </span>
+                            </div>
+                            <div class="mt-4">
+                                <a href="{{ route('edit.article', $myPost->id) }}" 
+                                   class="bg-orange-500 hover:bg-orange-600 text-white font-bold py-2 px-4 rounded-lg transition duration-300 ease-in-out">
+                                    編集
+                                </a>
                             </div>
                         </div>
                     </article>
@@ -53,9 +54,7 @@
 
             <!-- ページネーション -->
             <div class="mt-10 pt-8 border-t border-gray-200">
-                <div class="pagination-custom space-y-4">
-                    {{ $myPosts->links() }}
-                </div>
+                {{ $myPosts->links() }}
             </div>
         </main>
     </div>

--- a/resources/views/top.blade.php
+++ b/resources/views/top.blade.php
@@ -1,34 +1,35 @@
 <x-app-layout>
-    <body class="bg-gray-50 min-h-screen">
-        
-        <main class="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-8">
+    <div class="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-8">
+        <!-- メインコンテンツ -->
+        <main class="bg-white rounded-lg shadow-md p-6 sm:p-8">
+            <!-- ヘッダーセクション -->
+            <div class="flex flex-col sm:flex-row justify-between items-start sm:items-center mb-8 pb-6 border-b-2 border-gray-200">
+                <h1 class="text-3xl font-bold text-gray-800 mb-4 sm:mb-0">投稿一覧</h1>
+            </div>
+
             <!-- Search Section -->
-            <div class="bg-white rounded-lg shadow-sm p-6 mb-8">
+            <div class="mb-8">
                 <form method="GET" action="{{ route('top') }}" class="space-y-4">
                     <div class="flex flex-col sm:flex-row gap-4">
                         <div class="flex-1">
                             <input 
                                 type="text" 
                                 name="search" 
-                                placeholder="Search articles..."
+                                placeholder="ポストを検索"
                                 class="w-full px-4 py-2 border border-gray-300 rounded-lg focus:ring-2 focus:ring-blue-500 focus:border-transparent outline-none transition-colors"
                                 value="{{ request('search') }}"
                             >
                         </div>
-                        
-                        <!-- カテゴリー選択 -->
                         <div class="sm:w-48">
                             <select name="category" class="w-full px-4 py-2 border border-gray-300 rounded-lg focus:ring-2 focus:ring-blue-500 focus:border-transparent outline-none transition-colors bg-white">
                                 <option value="">全てのカテゴリー</option>
                                 @foreach(Category::cases() as $category) 
-                                    <option value="{{ $category->value }}" 
-                                        {{ request('category') == $category->value ? 'selected' : '' }}>
+                                    <option value="{{ $category->value }}" {{ request('category') == $category->value ? 'selected' : '' }}>
                                         {{ $category->label() }}
                                     </option>
                                 @endforeach
                             </select>
                         </div>
-                        
                         <button type="submit" class="px-6 py-2 bg-blue-600 text-white rounded-lg hover:bg-blue-700 focus:ring-2 focus:ring-blue-500 focus:ring-offset-2 transition-colors inline-flex items-center justify-center">
                             <svg class="w-5 h-5" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
                                 <circle cx="11" cy="11" r="8"></circle>
@@ -38,104 +39,52 @@
                         </button>
                     </div>
                 </form>
-                
-                <!-- アクティブなフィルターの表示 -->
-                @if(request('search') || request('category'))
-                    <div class="mt-4 pt-4 border-t border-gray-200">
-                        <div class="flex flex-wrap items-center gap-2">
-                            <span class="text-sm font-medium text-gray-700">フィルター:</span>
-                            
-                            @if(request('search'))
-                                <span class="inline-flex items-center px-3 py-1 bg-blue-100 text-blue-800 text-sm rounded-full">
-                                    検索: "{{ request('search') }}"
-                                    <a href="{{ request()->fullUrlWithQuery(['search' => null]) }}" class="ml-2 text-blue-600 hover:text-blue-800 font-bold">×</a>
-                                </span>
-                            @endif
-                            
-                            @if(request('category'))
-                                <span class="inline-flex items-center px-3 py-1 bg-green-100 text-green-800 text-sm rounded-full">
-                                    カテゴリー: {{ Category::from(request('category'))->label() }}
-                                    <a href="{{ request()->fullUrlWithQuery(['category' => null]) }}" class="ml-2 text-green-600 hover:text-green-800 font-bold">×</a>
-                                </span>
-                            @endif
-                            
-                            <a href="{{ route('top') }}" class="text-sm text-gray-600 hover:text-gray-800 underline">全てクリア</a>
-                        </div>
-                    </div>
-                @endif
             </div>
-    
+
             <!-- Blog articles Grid -->
             <div class="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-6">
                 @if($articles->isEmpty())
                     <div class="col-span-full text-center py-12">
-                        @if(request('search') || request('category'))
-                            <div class="text-gray-500 space-y-4">
-                                <svg class="w-16 h-16 mx-auto text-gray-300" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-                                    <path stroke-linecap="round" stroke-linejoin="round" stroke-width="1" d="M9.172 16.172a4 4 0 015.656 0M9 12h6m-6-4h6m2 5.291A7.962 7.962 0 0118 12a8 8 0 01-8 8 8 8 0 01-8-8 8 8 0 018-8c2.027 0 3.9.756 5.315 2"/>
-                                </svg>
-                                <p class="text-lg font-medium">検索条件に一致する投稿が見つかりませんでした。</p>
-                                <a href="{{ route('top') }}" class="inline-block px-4 py-2 bg-blue-600 text-white rounded-lg hover:bg-blue-700 transition-colors">
-                                    全ての投稿を表示
-                                </a>
-                            </div>
-                        @else
-                            <div class="text-gray-500 space-y-4">
-                                <svg class="w-16 h-16 mx-auto text-gray-300" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-                                    <path stroke-linecap="round" stroke-linejoin="round" stroke-width="1" d="M9 12h6m-6 4h6m2 5.291A7.962 7.962 0 0118 12a8 8 0 01-8 8 8 8 0 01-8-8 8 8 0 018-8c2.027 0 3.9.756 5.315 2"/>
-                                </svg>
-                                <p class="text-lg font-medium">投稿がありません。</p>
-                            </div>
-                        @endif
+                        <p class="text-lg font-medium text-gray-500">投稿がありません。</p>
                     </div>
                 @else
                     @foreach($articles as $article)
                         <a href="{{ route('post.show', $article->id)}}">
-                        <article class="bg-white rounded-lg shadow-sm hover:shadow-md transition-shadow duration-300 overflow-hidden">
-                            <div class="aspect-w-16 aspect-h-9">
-                                @if(!empty($article->image_path))
-                                    <img src="{{ $article->image_path }}" 
-                                         alt="{{ $article->title }}"
-                                         class="w-full h-48 object-cover">
-                                @else
-                                    <div class="w-full h-48 bg-gradient-to-br from-gray-200 to-gray-300 flex items-center justify-center">
-                                        <svg class="w-12 h-12 text-gray-400" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-                                            <path stroke-linecap="round" stroke-linejoin="round" stroke-width="1" d="M4 16l4.586-4.586a2 2 0 012.828 0L16 16m-2-2l1.586-1.586a2 2 0 012.828 0L20 14m-6-6h.01M6 20h12a2 2 0 002-2V6a2 2 0 00-2-2H6a2 2 0 00-2 2v12a2 2 0 002 2z"/>
-                                        </svg>
-                                    </div>
-                                @endif
-                            </div>
-                            
-                            <div class="p-6">
-                                <h2 class="text-lg font-semibold text-gray-900 hover:text-blue-600 transition-colors line-clamp-2 leading-tight mb-2">
-                                    {{ $article->title }}
-                                </h2>
-                                <p class="text-gray-600 mb-4 line-clamp-3">
-                                    {{ Str::limit($article->detail, 50) }}
-                                </p>
-                                
-                                <div class="flex items-center justify-between text-sm text-gray-500 mb-3">
-                                    <span class="font-medium">{{ $article->user->name ?? 'Unknown' }}</span>
-                                    <time class="text-gray-400">{{ $article->created_at->format('Y年m月d日') }}</time>
+                            <article class="bg-white border border-gray-200 rounded-lg overflow-hidden hover:shadow-md transition-shadow duration-300">
+                                <div class="aspect-w-16 aspect-h-9">
+                                    @if($article->image_path)
+                                        <img src="{{ $article->image_path }}" alt="{{ $article->title }}" class="w-full h-48 object-cover">
+                                    @else
+                                        <div class="w-full h-48 bg-gradient-to-br from-gray-200 to-gray-300 flex items-center justify-center">
+                                            <svg class="w-12 h-12 text-gray-400" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                                                <path stroke-linecap="round" stroke-linejoin="round" stroke-width="1" d="M4 16l4.586-4.586a2 2 0 012.828 0L16 16m-2-2l1.586-1.586a2 2 0 012.828 0L20 14m-6-6h.01M6 20h12a2 2 0 002-2V6a2 2 0 00-2-2H6a2 2 0 00-2 2v12a2 2 0 002 2z"/>
+                                            </svg>
+                                        </div>
+                                    @endif
                                 </div>
-                                
-                                <div class="inline-block">
+                                <div class="p-6">
+                                    <h2 class="text-lg font-semibold text-gray-900 hover:text-blue-600 transition-colors line-clamp-2 leading-tight mb-2">
+                                        {{ $article->title }}
+                                    </h2>
+                                    <p class="text-gray-600 mb-4 line-clamp-3">{{ Str::limit($article->detail, 50) }}</p>
+                                    <div class="flex items-center justify-between text-sm text-gray-500 mb-3">
+                                        <span class="font-medium">{{ $article->user->name ?? 'Unknown' }}</span>
+                                        <time class="text-gray-400">{{ $article->created_at->format('Y年m月d日') }}</time>
+                                    </div>
                                     <span class="px-3 py-1 bg-indigo-100 text-indigo-800 text-xs font-medium rounded-full">
                                         {{ $article->category_id->label() }}
                                     </span>
                                 </div>
-                            </div>
-                        </article>
+                            </article>
+                        </a>
                     @endforeach
                 @endif
             </div>
-    
+
             <!-- ページネーション -->
             <div class="mt-10 pt-8 border-t border-gray-200">
-                <div class="pagination-custom space-y-4">
-                    {{ $articles->links() }}
-                </div>
+                {{ $articles->links() }}
             </div>
         </main>
-    </body>
+    </div>
 </x-app-layout>


### PR DESCRIPTION
## 変更点
- 自分の投稿一覧それぞれの投稿に「編集」ボタンを設置
- それぞれ英語表記を日本語表記に統一
- 自分の投稿一覧と一覧画面のレイアウトをそろえる
- 未ログイン時にはヘッダーやメニューに「自分の投稿」を表示させない
- 自分の投稿一覧から個別に行けるようにする